### PR TITLE
[DRAFT] Add Execute+create new block mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 yarn.lock
 coverage
 node_modules
+.idea

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "build": "parcel build src/index.ts -o build/pyroam.js",
     "test": "jest --coverage"
   },
+  "dependencies": {
+    "roam-client": "^1.76.3"
+  },
   "devDependencies": {
     "@babel/core": "^7.13.8",
     "@babel/preset-env": "^7.13.9",

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,5 +1,5 @@
 import {processCodeBlocks} from "./helpers"
-import {createBlock} from "roam-client"
+import {createBlock, getOrderByBlockUid, getParentUidByBlockUid} from "roam-client"
 
 /* === WRAPPERS === */
 export const q = async (query) => {
@@ -80,3 +80,20 @@ export const getAllCodeBlocksNestedUnder = async (topUid) => {
             [(clojure.string/starts-with? ?string "```python")]]')
   return processCodeBlocks(results, topUid);
 };
+
+export async function createNextPythonBlock(activeUid: string) {
+  // todo generate hiccup for displaying complex things?
+  // todo interactive output
+  // todo proper click on the new code block
+
+  const order = getOrderByBlockUid(activeUid) + 1
+  const newUuid = createBlock({
+    node: {
+      text: "```python\n```",
+    },
+    parentUid: getParentUidByBlockUid(activeUid),
+    order,
+  })
+
+  console.log("Created new python block:", newUuid)
+}

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,8 +1,8 @@
-import { createUid, processCodeBlocks } from "./helpers";
+import {processCodeBlocks} from "./helpers"
+import {createBlock} from "roam-client"
 
 /* === WRAPPERS === */
 export const q = async (query) => {
-  //@ts-ignore
   const result = await window.roamAlphaAPI.q(query);
   if (!result || result.length === 0) {
     return null;
@@ -10,22 +10,7 @@ export const q = async (query) => {
 };
 
 export const updateBlock = async (uid, string) => {
-  //@ts-ignore
   await window.roamAlphaAPI.updateBlock({
-    block: {
-      uid: uid,
-      string: string,
-    },
-  });
-};
-
-export const createBlock = async (parentUid, order, uid, string) => {
-  //@ts-ignore
-  await window.roamAlphaAPI.createBlock({
-    location: {
-      "parent-uid": parentUid,
-      order: order,
-    },
     block: {
       uid: uid,
       string: string,
@@ -54,11 +39,14 @@ export const writeToNestedBlock = async (parentUid, string) => {
 
   const result = await q(query);
   if (!result) {
-    const nestedUid = createUid();
-    createBlock(parentUid, 0, nestedUid, string);
+    createBlock({
+      node: {text: string},
+      parentUid,
+      order: 0
+    })
   } else {
     const nestedUid = result[0][0].uid;
-    updateBlock(nestedUid, string);
+    return updateBlock(nestedUid, string);
   }
 };
 
@@ -84,13 +72,11 @@ export const getUidOfClosestBlockReferencing = async (uid: string, page: string)
 };
 
 export const getAllCodeBlocksNestedUnder = async (topUid) => {
-  //@ts-ignore
-  var results = await window.roamAlphaAPI.q('[:find\
+  const results = await window.roamAlphaAPI.q('[:find\
     (pull ?cell [:block/string :block/order :block/uid {:block/_children ...}])\
     :where  [?notebookBlock :block/uid "' + topUid + '"]\
             [?cell :block/parents ?notebookBlock]\
             [?cell :block/string ?string]\
-            [(clojure.string/starts-with? ?string "```python")]]');
-  const cells = processCodeBlocks(results, topUid);
-  return cells;
+            [(clojure.string/starts-with? ?string "```python")]]')
+  return processCodeBlocks(results, topUid);
 };

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -20,27 +20,6 @@ export const addScriptToPage = (tagId, script) => {
   );
 };
 
-export const createUid = () => {
-  // From roam42 based on https://github.com/ai/nanoid#js version 3.1.2
-  let nanoid = (t = 21) => {
-    let e = "",
-      r = crypto.getRandomValues(new Uint8Array(t));
-    for (; t--;) {
-      let n = 63 & r[t];
-      e +=
-        n < 36
-          ? n.toString(36)
-          : n < 62
-            ? (n - 26).toString(36).toUpperCase()
-            : n < 63
-              ? "_"
-              : "-";
-    }
-    return e;
-  };
-  return nanoid(9);
-};
-
 export const getActiveBlockUid = () => {
   const el = document.activeElement;
   const uid = el.closest(".rm-block__input").id.slice(-9);

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,4 +1,5 @@
 /* ====== BASIC ======= */
+
 export const sleep = (m) => {
   var t = m ? m : 10;
   return new Promise((r) => setTimeout(r, t));
@@ -20,11 +21,15 @@ export const addScriptToPage = (tagId, script) => {
   );
 };
 
+export function getActiveRoamInputElement() {
+  const el = document.activeElement
+  return el.closest(".rm-block__input")
+}
+
 export const getActiveBlockUid = () => {
-  const el = document.activeElement;
-  const uid = el.closest(".rm-block__input").id.slice(-9);
-  return uid;
-};
+  const roamInput = getActiveRoamInputElement()
+  return roamInput.id.slice(-9)
+}
 
 export const removeBackticks = (str: string) => {
   var ttt = "``" + "`";

--- a/src/keyboard.ts
+++ b/src/keyboard.ts
@@ -1,10 +1,13 @@
 
 import { runActiveBlockAndWriteToNext, runActiveNotebook } from "./notebook";
 
-export const handleKeyPress = async (e) => {
+export const handleKeyPress = async (e: KeyboardEvent) => {
   if (e.code === "Enter" && e.altKey === true && !e.shiftKey) {
     runActiveBlockAndWriteToNext();
   } else if (e.code === "Enter" && e.altKey === true && e.shiftKey === true) {
     runActiveNotebook();
+  } else if (e.key === "-" && e.ctrlKey === true && e.metaKey === true)  {
+    console.log("pyroam: Removing key listener")
+    document.removeEventListener("keydown", handleKeyPress)
   }
 };

--- a/src/keyboard.ts
+++ b/src/keyboard.ts
@@ -1,9 +1,14 @@
-
-import { runActiveBlockAndWriteToNext, runActiveNotebook } from "./notebook";
+import {runActiveBlockAndWriteToNext, runActiveNotebook} from "./notebook"
+import {getActiveBlockUid} from "./helpers"
+import {createNextPythonBlock} from "./api"
 
 export const handleKeyPress = async (e: KeyboardEvent) => {
   if (e.code === "Enter" && e.altKey === true && !e.shiftKey) {
-    runActiveBlockAndWriteToNext();
+      await runActiveBlockAndWriteToNext()
+  } else if (e.code === "Enter" && e.metaKey === true ) {
+      await runActiveBlockAndWriteToNext()
+      await createNextPythonBlock(getActiveBlockUid())
+      e.stopPropagation()
   } else if (e.code === "Enter" && e.altKey === true && e.shiftKey === true) {
     runActiveNotebook();
   } else if (e.key === "-" && e.ctrlKey === true && e.metaKey === true)  {

--- a/src/notebook.ts
+++ b/src/notebook.ts
@@ -1,16 +1,16 @@
-import { getActiveBlockUid, getActiveCodeBlockContent as getActiveCodeBlockContent, removeBackticks } from "./helpers";
-import { q, writeToNestedBlock, getUidOfClosestBlockReferencing, getAllCodeBlocksNestedUnder, getBlockStringByUid } from "./api";
-import { runPython } from "./pyodide";
+import {getActiveBlockUid, getActiveCodeBlockContent as getActiveCodeBlockContent} from "./helpers"
+import {getAllCodeBlocksNestedUnder, getUidOfClosestBlockReferencing, writeToNestedBlock} from "./api"
+import {runPython} from "./pyodide"
 
 
 const runAllBlocksBelowUidAndWrite = async (notebookUid) => {
-    const cells = await getAllCodeBlocksNestedUnder(notebookUid);
-    const activeUid = getActiveBlockUid();
+    const cells = await getAllCodeBlocksNestedUnder(notebookUid)
+    const activeUid = getActiveBlockUid()
 
     for (const cell of cells) {
         if (cell.uid === activeUid) cell.string = getActiveCodeBlockContent()
 
-        const out = await runPython(cell.string);
+        const out = await runPython(cell.string)
         await writeToNestedBlock(cell.uid, out)
     }
 }
@@ -19,18 +19,18 @@ const runAllBlocksBelowUidAndWrite = async (notebookUid) => {
  * Runs only the active cell
  */
 export const runActiveBlockAndWriteToNext = async () => {
-    const activeUid = getActiveBlockUid();
+    const activeUid = getActiveBlockUid()
     const code = getActiveCodeBlockContent()
     const out = await runPython(code)
     await writeToNestedBlock(activeUid, out)
-};
+}
 
 /**
  * Runs the whole notebook
  */
 export const runActiveNotebook = async () => {
-    const uid = getActiveBlockUid();
-    const notebookUid = await getUidOfClosestBlockReferencing(uid, "pyroam/notebook");
+    const uid = getActiveBlockUid()
+    const notebookUid = await getUidOfClosestBlockReferencing(uid, "pyroam/notebook")
     console.log("Notebook Block uid:" + notebookUid)
-    runAllBlocksBelowUidAndWrite(notebookUid);
+    runAllBlocksBelowUidAndWrite(notebookUid)
 }


### PR DESCRIPTION
this replaces #3 (new branch)
---
This adds execute + create new code block mode (similar to shift-enter in Jupyter). 

It works, but it's not quite up to a standard I want it to be - namely I'd really like the new code block to be selected after it's created. I failed to do that so far.  
I've tried simulating a mouse click on the code editor and it does not work for some reason 🤔 (even though clicking directly on the roam block works, but that's not desired.  

Would appreciate thoughts on how to properly do "activate new block part".

---
This PR also takes dependency on roam-client for some common roam-interaction functionality.